### PR TITLE
Move to building the standard debian package and then installing in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,31 +2,28 @@ FROM debian:12-slim@sha256:ccb33c3ac5b02588fc1d9e4fc09b952e433d0c54d8618d0ee1afa
 WORKDIR /app/git
 ARG TARGETPLATFORM
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git wget ca-certificates pkg-config autoconf gcc make libusb-1.0-0-dev librtlsdr-dev librtlsdr0 libncurses-dev zlib1g-dev zlib1g libzstd-dev libzstd1 && \
-    git clone --depth 1 --branch v3.14.1618 https://github.com/wiedehopf/readsb.git /app/git && \
-    make -j$(nproc) OPTIMIZE="-O2" ZLIB_STATIC=yes DISABLE_INTERACTIVE=yes STATIC=yes RTLSDR=yes && \
-    mv readsb /usr/local/bin && \
-    chmod +x /usr/local/bin/readsb && \
-    mkdir -p  /usr/local/share/tar1090 && \
-    wget -qO /usr/local/share/tar1090/aircraft.csv.gz https://github.com/wiedehopf/tar1090-db/raw/csv/aircraft.csv.gz
-# Since distroless doesn't have a shell, we have to queue up the supporting libraries to copy
-# in the builder.  Put them in /libs and then copy all of /libs over in the final image.
-WORKDIR /copylibs
-RUN LIB_ARCH=$(case ${TARGETPLATFORM} in \
-    "linux/amd64")   echo "x86_64-linux-gnu"  ;; \
-    "linux/arm/v7")  echo "arm-linux-gnueabihf"   ;; \
-    "linux/arm64")   echo "aarch64-linux-gnu" ;; \
-    *)               echo ""        ;; esac) \
-    && echo "LIB_ARCH=$LIB_ARCH" && \
-    mkdir -p /copylibs/${LIB_ARCH} && \
-    cp /lib/${LIB_ARCH}/libzstd.so.1 /copylibs/${LIB_ARCH}/libzstd.so.1 && \
-    cp /lib/${LIB_ARCH}/libusb-1.0.so.0 /copylibs/${LIB_ARCH}/libusb-1.0.so.0 && \
-    cp /lib/${LIB_ARCH}/libudev.so.1 /copylibs/${LIB_ARCH}/libudev.so.1 
+    apt-get install --no-install-recommends -y --no-install-recommends --no-install-suggests -y \
+    git ca-certificates wget build-essential debhelper libusb-1.0-0-dev \
+    librtlsdr-dev librtlsdr0 pkg-config \
+    libncurses-dev zlib1g-dev libzstd-dev apt-rdepends
+RUN git clone --depth 1 --branch v3.14.1618 https://github.com/wiedehopf/readsb.git /app/git && \
+    export DEB_BUILD_OPTIONS=noautodbgsym && \
+    dpkg-buildpackage -b -Prtlsdr -ui -uc -us
+RUN wget -qO /app/git/aircraft.csv.gz https://github.com/wiedehopf/tar1090-db/raw/csv/aircraft.csv.gz
+
+
+# This uses apt-rdepends to download the dependencies for readsb, removes the libc/gcc ones provided by distroless
+# and puts it all in the /newroot directory to be copied over to the stage 2 image
+WORKDIR /dpkg
+RUN mv /app/*.deb .
+RUN apt-get download --no-install-recommends $(apt-rdepends libusb-1.0-0 librtlsdr0 libncurses6 zlib1g libzstd1|grep -v "^ ") && \
+    rm libc* libgcc* gcc* 
+WORKDIR /newroot
+RUN dpkg --unpack -R --force-all --root=/newroot /dpkg/
 
 FROM gcr.io/distroless/cc-debian12:nonroot@sha256:548d3e91231ffc84c1543da0b63e4063defc1f9620aa969e7f5abfafeb35afbe
-COPY --from=builder /usr/local/bin/readsb /usr/local/bin/readsb
-COPY --from=builder /copylibs/* /lib/
-COPY --from=builder /usr/local/share/tar1090/aircraft.csv.gz /usr/local/share/tar1090/aircraft.csv.gz
+COPY --from=builder /newroot /
+COPY --from=builder /app/git/aircraft.csv.gz /usr/local/share/tar1090/aircraft.csv.gz
 
-# https://www.baeldung.com/ops/docker-cmd-override
-ENTRYPOINT ["/usr/local/bin/readsb"]
+ENTRYPOINT ["/usr/bin/readsb"]
+


### PR DESCRIPTION
distroless.  Possibly increases the size of the build, but its "standard", just minimized.